### PR TITLE
Ensure compatibility with both Python 2 and 3

### DIFF
--- a/netort/cli.py
+++ b/netort/cli.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import argparse
 
 from datetime import datetime

--- a/netort/data_manager/clients/local.py
+++ b/netort/data_manager/clients/local.py
@@ -5,7 +5,10 @@ import os
 import logging
 import json
 import threading
-import queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 import time
 from builtins import str
 
@@ -124,7 +127,7 @@ class ProcessingThread(threading.Thread):
                     }
                     self.client.registered_meta[metric_full_name] = this_metric_meta
                     artifact_file_header = json.dumps(this_metric_meta)
-                    self.file_streams[metric_full_name].write(u"%s\n" % artifact_file_header)
+                    self.file_streams[metric_full_name].write("%s\n" % artifact_file_header)
                 csv_data = df_grouped_by_id.to_csv(
                     sep=self.client.separator,
                     header=False,

--- a/netort/data_manager/clients/luna.py
+++ b/netort/data_manager/clients/luna.py
@@ -15,12 +15,11 @@ import six
 import pandas as pd
 import datetime
 import os
-import six
 if six.PY2:
-    import queue
+    import Queue as queue
 else:
     # noinspection PyUnresolvedReferences
-    import Queue as queue
+    import queue
 
 requests.packages.urllib3.disable_warnings()
 

--- a/netort/data_manager/clients/lunapark_volta.py
+++ b/netort/data_manager/clients/lunapark_volta.py
@@ -5,7 +5,10 @@ import time
 import datetime
 import os
 import pkg_resources
-import queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 
 from retrying import retry, RetryError
 

--- a/netort/data_manager/clients/tests/test_local.py
+++ b/netort/data_manager/clients/tests/test_local.py
@@ -105,7 +105,7 @@ def test_raw_metric(sin_data_frame, data_session):
     assert len(meta['metrics']) == 1, "Exactly one metric should have been written to meta.json"
 
     metric_id = list(meta['metrics'])[0]
-    metric_data_path = pathlib.Path(data_session.artifacts_dir) / f'{metric_id}.data'
+    metric_data_path = pathlib.Path(data_session.artifacts_dir) / '{metric_id}.data'.format(metric_id=metric_id)
     assert os.path.isfile(metric_data_path), "Metric data should have been written"
 
     with open(metric_data_path) as data_file:
@@ -158,7 +158,7 @@ def test_quantiles_metric(sin_data_frame, data_session):
     metric_ids = {v['type']: k for k, v in meta['metrics'].items()}
 
     q_metric_id = metric_ids['TypeQuantiles']
-    q_metric_data_path = pathlib.Path(data_session.artifacts_dir) / f'{q_metric_id}.data'
+    q_metric_data_path = pathlib.Path(data_session.artifacts_dir) / '{q_metric_id}.data'.format(q_metric_id=q_metric_id)
     assert os.path.isfile(q_metric_data_path), "Quantile data should have been written"
 
     with open(q_metric_data_path) as data_file:
@@ -177,7 +177,7 @@ def test_quantiles_metric(sin_data_frame, data_session):
     assert fields[1] == "0.0", "The q0 field should be equal to 0.0"
 
     d_metric_id = metric_ids['TypeDistribution']
-    d_metric_data_path = pathlib.Path(data_session.artifacts_dir) / f'{d_metric_id}.data'
+    d_metric_data_path = pathlib.Path(data_session.artifacts_dir) / '{d_metric_id}.data'.format(d_metric_id=d_metric_id)
     assert os.path.isfile(d_metric_data_path), "Distribution data should have been written"
 
     with open(d_metric_data_path) as data_file:
@@ -214,7 +214,7 @@ def test_raw_events(data_session, event_data_frame):
     assert len(meta['metrics']) == 1, "Exactly one events stream should have been written to meta.json"
 
     metric_id = list(meta['metrics'])[0]
-    metric_data_path = pathlib.Path(data_session.artifacts_dir) / f'{metric_id}.data'
+    metric_data_path = pathlib.Path(data_session.artifacts_dir) / '{metric_id}.data'.format(metric_id=metric_id)
     assert os.path.isfile(metric_data_path), "Metric data should have been written"
 
     with open(metric_data_path) as data_file:
@@ -254,7 +254,7 @@ def test_aggregated_events(data_session, event_data_frame):
     assert len(meta['metrics']) == 1, "Exactly one events stream should have been written to meta.json"
 
     metric_id = list(meta['metrics'])[0]
-    metric_data_path = pathlib.Path(data_session.artifacts_dir) / f'{metric_id}.data'
+    metric_data_path = pathlib.Path(data_session.artifacts_dir) / '{metric_id}.data'.format(metric_id=metric_id)
     assert os.path.isfile(metric_data_path), "Metric data should have been written"
 
     with open(metric_data_path) as data_file:

--- a/netort/data_manager/common/interfaces.py
+++ b/netort/data_manager/common/interfaces.py
@@ -3,7 +3,10 @@ import threading
 from collections import Counter
 
 import pandas as pd
-import queue
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 import uuid
 import numpy as np
 import logging
@@ -106,9 +109,9 @@ class TypeDistribution(Aggregated, DataType):
             [pd.DataFrame.from_dict(
                 {'l': bins[:-1],
                  'r': bins[1:],
-                 'cnt': data,
+                 'cnt': cnt,
                  'ts': ts}
-            ).query('cnt > 0') for ts, (data, bins) in data.items()]
+            ).query('cnt > 0') for ts, (cnt, bins) in data.items()]
         )
         return result
 

--- a/netort/data_processing.py
+++ b/netort/data_processing.py
@@ -1,5 +1,8 @@
 import logging
-import queue as q
+try:
+    import queue as q
+except ImportError:
+    import Queue as q
 import threading
 import time
 

--- a/netort/resource.py
+++ b/netort/resource.py
@@ -1,4 +1,6 @@
 """ Resource Opener tool """
+from __future__ import print_function
+
 import logging
 import os
 import requests

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ common library for yandex-load org
     packages=find_packages(exclude=["tests", "tmp", "docs", "data"]),
     install_requires=[
         'pyserial', 'requests', 'retrying', 'cerberus', 'six>=1.12.0', 'pandas>=0.23.0',
+        'pathlib',
     ],
     setup_requires=[
         # 'pytest-runner', 'flake8',

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='netort',
-    version='0.6.10',
+    version='0.6.11',
     description='common library for yandex-load org',
     longer_description='''
 common library for yandex-load org


### PR DESCRIPTION
Tests did throw errors on both Python versions.
Now they just fail.
Yandex.Tank could use this lib only with Python2.
Now it works with both versions.