### PR TITLE
Fast upload

### DIFF
--- a/netort/data_manager/clients/luna.py
+++ b/netort/data_manager/clients/luna.py
@@ -350,35 +350,34 @@ class WorkerThread(QueueWorker):
     def __update_max_length(self, new_length):
         return new_length if self.data['max_length'] < new_length else self.data['max_length']
 
-    def __update_df(self, data_type, input_df):
-        for metric_local_id, df_grouped_by_id in input_df.groupby(level=0, sort=False):
-            metric = self.client.job.manager.get_metric_by_id(metric_local_id)
+    def __update_df(self, data_type, df):
+        metric_local_id = df['metric_local_id'].iloc[0]
+        metric = self.client.job.manager.get_metric_by_id(metric_local_id)
 
-            if not metric:
-                logger.warning('Received unknown metric: %s! Ignored.', metric_local_id)
-                return pd.DataFrame([])
+        if not metric:
+            logger.warning('Received unknown metric: %s! Ignored.', metric_local_id)
+            return pd.DataFrame([])
 
-            if metric.local_id not in self.client.public_ids:
-                # no public_id yet, put it back
-                self.client.put(data_type, input_df)
-                logger.debug('No public id for metric {}'.format(metric.local_id))
-                self.client.register_worker.register(metric)
-                return pd.DataFrame([])
+        if metric.local_id not in self.client.public_ids:
+            # no public_id yet, put it back
+            self.client.put(data_type, df)
+            logger.debug('No public id for metric {}'.format(metric.local_id))
+            self.client.register_worker.register(metric)
+            return pd.DataFrame([])
 
-            df_grouped_by_id.loc[:, 'key_date'] = self.client.key_date
-            df_grouped_by_id.loc[:, 'tag'] = self.client.public_ids[metric.local_id]
-            result_df = df_grouped_by_id
+        df.loc[:, 'key_date'] = self.client.key_date
+        df.loc[:, 'tag'] = self.client.public_ids[metric.local_id]
 
-            if not result_df.empty:
-                table_name = data_type.table_name
-                if not self.data.get(table_name):
-                    self.data[table_name] = {
-                        'dataframe': result_df,
-                        'columns': self.client.luna_columns + data_type.columns,
-                    }
-                else:
-                    self.data[table_name]['dataframe'] = pd.concat([self.data[table_name]['dataframe'], result_df])
-                self.data['max_length'] = self.__update_max_length(len(self.data[table_name]['dataframe']))
+        if not df.empty:
+            table_name = data_type.table_name
+            if not self.data.get(table_name):
+                self.data[table_name] = {
+                    'dataframe': df,
+                    'columns': self.client.luna_columns + data_type.columns,
+                }
+            else:
+                self.data[table_name]['dataframe'] = pd.concat([self.data[table_name]['dataframe'], df])
+            self.data['max_length'] = self.__update_max_length(len(self.data[table_name]['dataframe']))
 
         if self.data['max_length'] >= MAX_DF_LENGTH:
             self.__upload_data()

--- a/netort/data_manager/clients/tests/test_luna.py
+++ b/netort/data_manager/clients/tests/test_luna.py
@@ -1,0 +1,23 @@
+from netort.data_manager.clients import LunaClient
+from netort.data_manager.common.interfaces import TypeEvents, TypeQuantiles, TypeHistogram, TypeTimeSeries, TypeDistribution
+import pandas as pd
+
+
+class TestLunaClient(object):
+
+    def setup_method(self):
+        self.luna_client = LunaClient(meta={'api_address': 'localhost'}, job=None)
+        self.df1 = pd.read_csv('netort/data_manager/tests/df1MetricData.csv')
+        self.df2 = pd.read_csv('netort/data_manager/tests/df2MetricData.csv')
+        self.events = TypeEvents()
+
+    def test_two(self):
+        self.luna_client.pending_queue.put([self.events, self.df1])
+        assert 5 == 5
+
+    def teardown(self):
+        # self.luna_client.register_worker.stop()
+        # self.luna_client.register_worker.join()
+        # self.luna_client.worker.stop()
+        # self.luna_client.worker.join()
+        pass

--- a/netort/data_manager/common/interfaces.py
+++ b/netort/data_manager/common/interfaces.py
@@ -161,7 +161,7 @@ class MetricData(object):
         :param data_types: list of DataType
         :param local_id: uuid4
         """
-        df['metric_local_id'] = local_id
+        df.loc[:, 'metric_local_id'] = local_id
         df = df.set_index('metric_local_id')
         self.data_types = data_types
         self.local_id = local_id

--- a/netort/data_manager/common/util.py
+++ b/netort/data_manager/common/util.py
@@ -1,5 +1,6 @@
 import collections
-
+import time
+import logging
 
 # TODO: rename to format_http_request
 def pretty_print(req):
@@ -20,3 +21,18 @@ def recursive_dict_update(d1, d2):
         else:
             d1[k] = d2[k]
     return d1
+
+
+def log_time_decorator(func):
+    """
+    logs func execution time
+    :param func:
+    :return:
+    """
+    def timed(*args, **kwargs):
+        start = time.time()
+        res = func(*args, **kwargs)
+        logging.debug('TIMER {}: {}'.format(func.__name__, round(time.time() - start, 3)))
+        return res
+
+    return timed

--- a/netort/data_manager/manager.py
+++ b/netort/data_manager/manager.py
@@ -1,30 +1,28 @@
-# TODO: move code that works with config to library's clients (e.g., Volta). Classes of this library should provide constructors with described arguments only
 import logging
 import uuid
 import time
 import os
 import getpass
 import six
-from netort.data_manager.metrics import Metric, Event
+from typing import Callable, Dict, Text, List, Union, Optional, Set, Type
+
+from .metrics import Metric, Event
+from .clients import available_clients
+from .router import MetricsRouter
+from .common.interfaces import AbstractMetric, DataType
 
 if six.PY3:
     from queue import Queue
 else:  # six.PY2
+    # noinspection PyUnresolvedReferences
     from Queue import Queue
-
-import pandas as pd
-
-from .clients import available_clients
-from .router import MetricsRouter
-
-import warnings
-# FIXME: this one is dangerous because it ignores all FutureWarnings, not only required one
-warnings.filterwarnings("ignore", category=FutureWarning)  # pandas sorting warnings
-
 
 logger = logging.getLogger(__name__)
 
 
+# TODO: move code that works with config to library's clients (e.g., Volta).
+# Classes of this library should provide constructors with described arguments only
+# noinspection PyBroadException
 class DataSession(object):
     """
     Workflow:
@@ -41,52 +39,56 @@ class DataSession(object):
 
     TODO:
         * move config parameters to kwargs, describe them here
-        * chunkify data for upload inside the uploader code
         * fight performance issues (probably caused by poor pandas write_csv performance)
     """
     def __init__(self,  config, test_start=None):
-        self.config = config
-        self.operator = self.__get_operator()
-        self.job_id = config.get('test_id', 'job_{uuid}'.format(uuid=uuid.uuid4()))
+        self.start_ts = time.time()                                                  # type: float
+        self.config = config                                                         # type: Dict
+        self.operator = self.__get_operator()                                        # type: Text
+        self.job_id = config.get('test_id', 'job_{uuid}'.format(uuid=uuid.uuid4()))  # type: Text
         logger.info('Created new local data session: %s', self.job_id)
-        self.test_start = test_start if test_start else int(time.time() * 10**6)
-        self.artifacts_base_dir = config.get('artifacts_base_dir', './logs')
-        self._artifacts_dir = None
-        self.manager = DataManager()
+        self.test_start = test_start if test_start else int(time.time() * 10**6)     # type: float
+        self.artifacts_base_dir = config.get('artifacts_base_dir', './logs')         # type: Text
+        self._artifacts_dir = None                                                   # type: Union[Text, None]
+        self.manager = DataManager()                                                 # type: DataManager
 
-        self.clients = []
+        self.clients = []                                                            # type: List
         self.__create_clients(config.get('clients', []))
         logger.debug('DataSession clients: %s', self.clients)
-        logger.debug('DataSession subscribers: %s', self.manager.subscribers)
 
     # TODO: extract client creation as factory method
     # TODO: consider removing clients from config and add them via `new_client` method
     def __create_clients(self, clients):
+        # type: (Dict) -> None
         for client_meta in clients:
             type_ = client_meta.get('type')
-            filter_ = client_meta.get('filter', {'type': '__ANY__'})
             if not type_:
                 raise ValueError('Client type should be defined.')
             if type_ in available_clients:
                 client = available_clients[type_](client_meta, self)
-                self.subscribe(client.put, filter_)
+                self.subscribe(client.put)
                 self.clients.append(client)
             else:
                 raise NotImplementedError('Unknown client type: %s' % type_)
 
     def new_true_metric(self, name, raw=True, aggregate=False, **kw):
+        # type: (Text, bool, bool, **Dict) -> Type[Metric]
         return self.manager.new_true_metric(name, self.test_start, raw, aggregate, **kw)
 
     def new_event_metric(self, name, raw=True, aggregate=False, **kw):
+        # type: (Text, bool, bool, **Dict) -> Type[Event]
         return self.manager.new_event_metric(name, self.test_start, raw, aggregate, **kw)
 
-    def subscribe(self, callback, filter_):
-        return self.manager.subscribe(callback, filter_)
+    def subscribe(self, callback):
+        # type: (Callable) -> Any
+        return self.manager.subscribe(callback)
 
     def get_metric_by_id(self, id_):
+        # type: (Text) -> Any
         return self.manager.get_metric_by_id(id_)
 
     def update_job(self, meta):
+        # type: (Dict) -> Any
         for client in self.clients:
             try:
                 client.update_job(meta)
@@ -97,6 +99,7 @@ class DataSession(object):
                 logger.debug('Client job updated: %s', client)
 
     def update_metric(self, meta):
+        # type: (Dict) -> None
         for client in self.clients:
             try:
                 client.update_metric(meta)
@@ -109,6 +112,7 @@ class DataSession(object):
     # TODO: artifacts dir should be inside "local" client. Or does it?
     @property
     def artifacts_dir(self):
+        # type: () -> Text
         if not self._artifacts_dir:
             dir_name = "{dir}/{id}".format(dir=self.artifacts_base_dir, id=self.job_id)
             if not os.path.isdir(dir_name):
@@ -118,6 +122,7 @@ class DataSession(object):
         return self._artifacts_dir
 
     def __get_operator(self):
+        # type: () -> Text
         try:
             return self.config.get('operator') or getpass.getuser()
         except:  # noqa: E722
@@ -127,6 +132,7 @@ class DataSession(object):
             raise
 
     def close(self, test_end):
+        # type: (float) -> None
         logger.info('DataSession received close signal.')
         logger.info('Closing DataManager')
         self.manager.close()
@@ -141,8 +147,10 @@ class DataSession(object):
             else:
                 logger.debug('Client closed: %s', client)
         logger.info('DataSession finished!')
+        logger.info('DataSession time: %s', time.time() - self.start_ts)
 
     def interrupt(self):
+        # type: () -> None
         self.manager.interrupt()
         for client in self.clients:
             try:
@@ -162,180 +170,116 @@ class DataManager(object):
     MetricsRouter is a facility that DataManager uses for passing incoming data to subscribers.
 
     Attributes:
-        metrics (dict): All registered metrics for DataManager session
-        subscribers (pd.DataFrame): All registered subscribers for DataManager session
-        callbacks (pd.DataFrame): callbacks for metric ids <-> subscribers' callbacks, used by router
-        routing_queue (Queue): incoming unrouted metrics data,
-            will be processed by MetricsRouter to subscribers' callbacks
+        metrics: All registered metrics for DataManager session
+        subscribers: All registered subscribers for DataManager session
+        callbacks: callbacks for metric ids <-> subscribers' callbacks, used by router
+        routing_queue: incoming unrouted metrics data, will be processed by MetricsRouter to subscribers' callbacks
         router (MetricsRouter object): Router thread. Read routing queue, concat incoming messages by metrics.type,
             left join by callback and call callback w/ resulting dataframe
     """
     def __init__(self):
-        self.metrics = {}
-        self.metrics_meta = pd.DataFrame(columns=['type'])
-        self.subscribers = pd.DataFrame(columns=['type'])
-        self.callbacks = pd.DataFrame(columns=['id', 'callback'])
-        self.routing_queue = Queue()
-        self.router = MetricsRouter(self)
+        self.metrics = {}                   # type: Dict[Text, AbstractMetric]
+        self.metrics_meta = {}              # type: Dict[Text, Text]
+        self.subscribers = {}               # type: Dict[Text, Callable]
+        self.callbacks = {}                 # type: Dict[Text, Set]
+        self.routing_queue = Queue()        # type: Queue
+        self.router = MetricsRouter(self)   # type: MetricsRouter
         self.router.start()
 
     def new_true_metric(self, name, test_start, raw=True, aggregate=False, **kw):
+        # type: (Text, float, bool, bool, **Dict) -> Type[Metric]
         """
         Create and register metric,
         find subscribers for this metric (using meta as filter) and subscribe
 
         Return:
-            metric (available_metrics[0]): one of Metric
+            metric: one of Metric
         """
         return self._new_metric(Metric, test_start, raw, aggregate, name=name, **kw)
 
     def new_event_metric(self, name, test_start, raw=True, aggregate=False, **kw):
+        # type: (Text, float, bool, bool, **Dict) -> Type[Event]
         return self._new_metric(Event, test_start, raw, aggregate, name=name, **kw)
 
     def _new_metric(self, dtype, test_start, raw=True, aggregate=False, **kw):
+        # type: (Optional[AbstractMetric], float, bool, bool, **Dict) -> Optional[AbstractMetric]
         metric_obj = dtype(kw, self.routing_queue, test_start, raw=raw, aggregate=aggregate)  # create metric object
-        metric_meta = pd.DataFrame({metric_obj.local_id: kw}).T  # create metric meta
-        self.metrics_meta.append(metric_meta)  # register metric meta
+        self.metrics_meta = kw  # register metric meta
         self.metrics[metric_obj.local_id] = metric_obj  # register metric object
-
-        # find subscribers for this metric
-        this_metric_subscribers = self.__reversed_filter(self.subscribers, kw)
-        if this_metric_subscribers.empty:
-            logger.debug('subscriber for metric %s not found', metric_obj.local_id)
-        else:
-            logger.debug('Found subscribers for this metric, subscribing...: %s', this_metric_subscribers)
-            # attach this metric id to discovered subscribers and select id <-> callbacks
-            this_metric_subscribers['id'] = metric_obj.local_id
-            found_callbacks = this_metric_subscribers[['id', 'callback']].set_index('id')
-            # add this metric callbacks to DataManager's callbacks
-            self.callbacks = self.callbacks.append(found_callbacks)
+        for callback in self.callbacks:
+            self.callbacks[callback].add(metric_obj.local_id)
         return metric_obj
 
-    def subscribe(self, callback, filter_):
+    def subscribe(self, callback):
+        # type: (Callable) -> None
         """
         Create and register metric subscriber,
-        find metrics for this subscriber (using filter_) and subscribe
+        subscribe all existing metrics for it
 
         Args:
             callback (object method): subscriber's callback
-            filter_ (dict): filter dict
-
-        filter sample:
-            {'type': 'metrics', 'source': 'gun'}
         """
         sub_id = "subscriber_{uuid}".format(uuid=uuid.uuid4())
         # register subscriber in manager
-        sub = pd.DataFrame({sub_id: filter_}).T
-        sub['callback'] = callback
-        self.subscribers = self.subscribers.append(sub)
-
-        # find metrics for subscriber using `filter`
-        this_subscriber_metrics = self.__filter(self.metrics_meta, filter_)
-        if this_subscriber_metrics.empty:
-            logger.debug('Metrics for subscriber %s not found', sub_id)
-        else:
-            logger.debug('Found metrics for this subscriber, subscribing...: %s', this_subscriber_metrics)
-            # attach this sub callback to discovered metrics and select id <-> callbacks
-            this_subscriber_metrics['callback'] = callback
-            prepared_callbacks = this_subscriber_metrics[['callback']]
-            # add this subscriber callbacks to DataManager's callbacks
-            self.callbacks = self.callbacks.append(prepared_callbacks)
+        self.subscribers[sub_id] = callback
+        self.callbacks[sub_id] = set(iter(self.metrics))
 
     def get_metric_by_id(self, id_):
+        # type: (Text) -> Optional[AbstractMetric]
         return self.metrics.get(id_)
 
-    @staticmethod
-    def __filter(filterable, filter_, logic_operation='and'):
-        """ filtering DataFrame using filter_ key-value conditions applying logic_operation
-        only find rows strictly fitting the filter_ criterion"""
-        condition = []
-        if not filter_:
-            return filterable
-        elif filter_.get('type') == '__ANY__':
-            return filterable
-        else:
-            for key, value in filter_.items():
-                condition.append('{key} == "{value}"'.format(key=key, value=value))
-        try:
-            res = filterable.query(" {operation} ".format(operation=logic_operation).join(condition))
-        except pd.core.computation.ops.UndefinedVariableError:
-            return pd.DataFrame()
-        else:
-            return res
-
-    @staticmethod
-    def __reversed_filter(filterable, filter_, logic_operation='and'):
-        """ reverse filtering DataFrame using filter_ key-value conditions applying logic_operation
-        find rows where existing filterable columns (and its values) fitting the filter_ criterion"""
-        condition = []
-        try:
-            subscribers_for_any = filterable.query('type == "__ANY__"')
-        except pd.core.computation.ops.UndefinedVariableError:
-            subscribers_for_any = pd.DataFrame()
-        if not filter_:
-            return filterable
-        else:
-            for existing_col in filterable:
-                for meta_tag, meta_value in filter_.items():
-                    if meta_tag == existing_col:
-                        condition.append('{key} == "{value}"'.format(key=meta_tag, value=meta_value))
-            try:
-                res = filterable.query(" {operation} ".format(operation=logic_operation).join(condition))
-            except (pd.core.computation.ops.UndefinedVariableError, ValueError):
-                return pd.DataFrame().append(subscribers_for_any)
-            else:
-                return res.append(subscribers_for_any)
-
     def close(self):
+        # type: () -> None
         self.router.close()
 
     def interrupt(self):
+        # type: () -> None
         self.router.interrupt()
         self.router.join()
 
 
-def usage_sample():
-    import time
-    import pandas as pd
-    config = {
-        'clients': [
-            {
-                'type': 'luna',
-                'api_address': 'http://hostname.tld',
-                'user_agent': 'Tank Test',
-            },
-            {
-                'type': 'local_storage',
-            }
-        ],
-        'test_start': time.time(),
-        'artifacts_base_dir': './logs'
-    }
-    data_session = DataSession(config=config)
-
-    metric_meta = {
-        'type': 'metrics',
-        'name': 'cpu_usage',
-        'hostname': 'localhost',
-        'some_meta_key': 'some_meta_value'
-    }
-
-    metric_obj = data_session.new_true_metric('name', **metric_meta)
-    time.sleep(1)
-    df = pd.DataFrame([[123, 123.123, "trash"]], columns=['ts', 'value', 'trash'])
-    metric_obj.put(df)
-    df2 = pd.DataFrame([[456, 456.456]], columns=['ts', 'value'])
-    metric_obj.put(df2)
-    time.sleep(10)
-    df = pd.DataFrame([[123, 123.123]], columns=['ts', 'value'])
-    metric_obj.put(df)
-    df2 = pd.DataFrame([[456, 456.456]], columns=['ts', 'value'])
-    metric_obj.put(df2)
-    time.sleep(10)
-    data_session.close()
+# def usage_sample():
+#     import time
+#     import pandas as pd
+#     config = {
+#         'clients': [
+#             {
+#                 'type': 'luna',
+#                 'api_address': 'http://hostname.tld',
+#                 'user_agent': 'Tank Test',
+#             },
+#             {
+#                 'type': 'local_storage',
+#             }
+#         ],
+#         'test_start': time.time(),
+#         'artifacts_base_dir': './logs'
+#     }
+#     data_session = DataSession(config=config)
+#
+#     metric_meta = {
+#         'type': 'metrics',
+#         'name': 'cpu_usage',
+#         'hostname': 'localhost',
+#         'some_meta_key': 'some_meta_value'
+#     }
+#
+#     metric_obj = data_session.new_true_metric('name', **metric_meta)
+#     time.sleep(1)
+#     df = pd.DataFrame([[123, 123.123, "trash"]], columns=['ts', 'value', 'trash'])
+#     metric_obj.put(df)
+#     df2 = pd.DataFrame([[456, 456.456]], columns=['ts', 'value'])
+#     metric_obj.put(df2)
+#     time.sleep(10)
+#     df = pd.DataFrame([[123, 123.123]], columns=['ts', 'value'])
+#     metric_obj.put(df)
+#     df2 = pd.DataFrame([[456, 456.456]], columns=['ts', 'value'])
+#     metric_obj.put(df2)
+#     time.sleep(10)
+#     data_session.close(test_end=time.time())
 
 
 if __name__ == '__main__':
     logging.basicConfig(level='DEBUG')
     logger = logging.getLogger(__name__)
-    usage_sample()
+    # usage_sample()

--- a/netort/data_manager/manager.py
+++ b/netort/data_manager/manager.py
@@ -9,7 +9,7 @@ from typing import Callable, Dict, Text, List, Union, Optional, Set, Type
 from .metrics import Metric, Event
 from .clients import available_clients
 from .router import MetricsRouter
-from .common.interfaces import AbstractMetric, DataType
+from .common.interfaces import AbstractMetric, DataType, MetricData
 
 if six.PY3:
     from queue import Queue
@@ -202,7 +202,7 @@ class DataManager(object):
         return self._new_metric(Event, test_start, raw, aggregate, name=name, **kw)
 
     def _new_metric(self, dtype, test_start, raw=True, aggregate=False, **kw):
-        # type: (Optional[AbstractMetric], float, bool, bool, **Dict) -> Optional[AbstractMetric]
+        # type: (Optional[AbstractMetric], float, bool, bool, **Dict) -> MetricData
         metric_obj = dtype(kw, self.routing_queue, test_start, raw=raw, aggregate=aggregate)  # create metric object
         self.metrics_meta = kw  # register metric meta
         self.metrics[metric_obj.local_id] = metric_obj  # register metric object

--- a/netort/data_manager/router.py
+++ b/netort/data_manager/router.py
@@ -50,7 +50,8 @@ class MetricsRouter(threading.Thread):
 
     def _from_buffer(self, metric_data, last_piece):
         """
-        Stores incoming data in local buffer to aggregate it in chunks
+        :type metric_data: netort.data_manager.common.interfaces.MetricData
+        :rtype: pd.DataFrame
         """
         buffered = self.__buffer.pop(metric_data.local_id, None)
         df = pd.concat([buffered, metric_data.df]) if buffered is not None else metric_data.df

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='netort',
-    version='0.7.0',
+    version='0.7.1',
     description='common library for yandex-load org',
     longer_description='''
 common library for yandex-load org


### PR DESCRIPTION
Simplify subscriber logic: all metrics are pushed to current subscribers.
Every dataframe coming from Volta or Tank has only one metric id so there is no need to group data by metric local id.