### PR TITLE
Fix close_job for luna client

### DIFF
--- a/netort/data_manager/clients/luna.py
+++ b/netort/data_manager/clients/luna.py
@@ -198,7 +198,7 @@ class LunaClient(AbstractClient):
                 api_address=self.api_address,
                 path=self.close_job_path,
             ),
-            params={'job': self._job_number,
+            params={'job': self.job_number,
                     'duration': int(duration)}
         )
         prepared_req = req.prepare()

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='netort',
-    version='0.7.5',
+    version='0.7.6',
     description='common library for yandex-load org',
     longer_description='''
 common library for yandex-load org


### PR DESCRIPTION
Job id was not added to ```close_job``` request in luna client, so duration is not shown for tank tests